### PR TITLE
Fix an issue that promise was not called / handled on android

### DIFF
--- a/android/src/main/java/com/proxima/RCTDigits/DigitsManager.java
+++ b/android/src/main/java/com/proxima/RCTDigits/DigitsManager.java
@@ -12,6 +12,8 @@ import com.digits.sdk.android.DigitsClient;
 import com.digits.sdk.android.DigitsException;
 import com.digits.sdk.android.DigitsOAuthSigning;
 import com.digits.sdk.android.DigitsSession;
+
+import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -27,16 +29,20 @@ import java.util.Map;
 
 import io.fabric.sdk.android.Fabric;
 
-public class DigitsManager extends ReactContextBaseJavaModule {
+public class DigitsManager extends ReactContextBaseJavaModule implements LifecycleEventListener, AuthCallback {
+
     private static final String META_DATA_KEY = "io.fabric.ApiKey";
     private static final String META_DATA_SECRET = "io.fabric.ApiSecret";
     private static final String TAG = "RCTDigits";
-    volatile DigitsClient digitsClient;
-    private ReactApplicationContext mContext;
+
+    private boolean paused = false;
+
+    private Promise promise;
+    private DigitsSession digitsSession;
+    private DigitsException digitsException;
 
     public DigitsManager(ReactApplicationContext reactContext) {
         super(reactContext);
-        mContext = reactContext;
     }
 
     @Override
@@ -46,34 +52,21 @@ public class DigitsManager extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void launchAuthentication(ReadableMap options, final Promise promise) {
-        TwitterAuthConfig authConfig = getTwitterConfig();
-        Fabric.with(mContext, new TwitterCore(authConfig), new Digits());
+        if (this.promise != null) {
+            promise.reject("Authentification process still in progress.");
+            return;
+        }
+
+        getReactApplicationContext().addLifecycleEventListener(this);
+        this.promise = promise;
 
         String phoneNumber = options.hasKey("phoneNumber") ? options.getString("phoneNumber") : "";
 
-        AuthCallback callback = new AuthCallback() {
-            @Override
-            public void success(DigitsSession session, String phoneNumber) {
-                TwitterAuthConfig authConfig = TwitterCore.getInstance().getAuthConfig();
-                TwitterAuthToken authToken = (TwitterAuthToken) session.getAuthToken();
-                DigitsOAuthSigning oauthSigning = new DigitsOAuthSigning(authConfig, authToken);
-                Map<String, String> authHeaders = oauthSigning.getOAuthEchoHeadersForVerifyCredentials();
-                WritableNativeMap authHeadersNativeMap = new WritableNativeMap();
+        TwitterAuthConfig authConfig = getTwitterAuthConfig();
+        Fabric.with(getReactApplicationContext(), new TwitterCore(authConfig), new Digits());
 
-                for (Map.Entry<String, String> entry : authHeaders.entrySet()) {
-                    authHeadersNativeMap.putString(entry.getKey(), entry.getValue());
-                }
-
-                promise.resolve(authHeadersNativeMap);
-            }
-
-            @Override
-            public void failure(DigitsException exception) {
-                promise.reject(exception.getMessage());
-            }
-        };
         DigitsAuthConfig.Builder digitsAuthConfigBuilder = new DigitsAuthConfig.Builder()
-                .withAuthCallBack(callback)
+                .withAuthCallBack(this)
                 .withPhoneNumber(phoneNumber)
                 .withThemeResId(R.style.CustomDigitsTheme);
 
@@ -85,31 +78,85 @@ public class DigitsManager extends ReactContextBaseJavaModule {
         Digits.getSessionManager().clearActiveSession();
     }
 
-    private TwitterAuthConfig getTwitterConfig() {
-        String key = getMetaData(META_DATA_KEY);
-        String secret = getMetaData(META_DATA_SECRET);
-
-        return new TwitterAuthConfig(key, secret);
-    }
-
-    // adapted from http://stackoverflow.com/questions/7500227/get-applicationinfo-metadata-in-oncreate-method
-    private String getMetaData(String name) {
+    private TwitterAuthConfig getTwitterAuthConfig() {
         try {
-            ApplicationInfo ai = mContext.getPackageManager().getApplicationInfo(
-                    mContext.getPackageName(),
+            ReactApplicationContext context = getReactApplicationContext();
+            PackageManager packageManager = context.getPackageManager();
+            ApplicationInfo applicationInfo = packageManager.getApplicationInfo(
+                    context.getPackageName(),
                     PackageManager.GET_META_DATA
             );
-
-            Bundle metaData = ai.metaData;
+            Bundle metaData = applicationInfo.metaData;
             if (metaData == null) {
-                Log.w(TAG, "metaData is null. Unable to get meta data for " + name);
-            } else {
-                String value = metaData.getString(name);
-                return value;
+                Log.w(TAG, "Application metaData is null. Unable to get Digits configuration.");
+                return null;
             }
+            String key = metaData.getString(META_DATA_KEY);
+            String secret = metaData.getString(META_DATA_SECRET);
+            if (key == null || secret == null) {
+                Log.w(TAG, "Application metaData does not contain Digits configuration.");
+                return null;
+            }
+            return new TwitterAuthConfig(key, secret);
         } catch (PackageManager.NameNotFoundException e) {
-            e.printStackTrace();
+            Log.w(TAG, "Error while configure Digits: " + e, e);
+            return null;
         }
-        return null;
+    }
+
+    @Override
+    public void success(DigitsSession session, String phoneNumber) {
+        digitsSession = session;
+        invokePromise();
+    }
+
+    @Override
+    public void failure(DigitsException exception) {
+        digitsException = exception;
+    }
+
+    @Override
+    public void onHostResume() {
+        paused = false;
+        invokePromise();
+    }
+
+    @Override
+    public void onHostPause() {
+        paused = true;
+    }
+
+    @Override
+    public void onHostDestroy() {
+        paused = true;
+    }
+
+    private void invokePromise() {
+        if (promise == null || paused) {
+            return;
+        }
+
+        if (digitsSession != null) {
+            TwitterAuthConfig authConfig = TwitterCore.getInstance().getAuthConfig();
+            TwitterAuthToken authToken = (TwitterAuthToken) digitsSession.getAuthToken();
+            DigitsOAuthSigning oauthSigning = new DigitsOAuthSigning(authConfig, authToken);
+            Map<String, String> authHeaders = oauthSigning.getOAuthEchoHeadersForVerifyCredentials();
+            WritableNativeMap authHeadersNativeMap = new WritableNativeMap();
+
+            for (Map.Entry<String, String> entry : authHeaders.entrySet()) {
+                authHeadersNativeMap.putString(entry.getKey(), entry.getValue());
+            }
+
+            promise.resolve(authHeadersNativeMap);
+        } else if (digitsException != null) {
+            promise.reject(digitsException.toString());
+        } else {
+            promise.reject("Authentification failed without exception.");
+        }
+
+        promise = null;
+        digitsSession = null;
+        digitsException = null;
+        getReactApplicationContext().removeLifecycleEventListener(this);
     }
 }


### PR DESCRIPTION
Problems happen "only" in the common case that login was called and there is no Digits session.

When the new activity was open and the callback was called before the react-native app is shown the application never receives the promise solve handler .then().

With an delay, or, in this case with an Lifecycle listener which waits until "onResume" was called this works fine.

A new npm release would be great after merging. :smirk: 
