### PR TITLE
Fix sessionDetails API to be same as iOS

### DIFF
--- a/android/src/main/java/com/proxima/RCTDigits/DigitsManager.java
+++ b/android/src/main/java/com/proxima/RCTDigits/DigitsManager.java
@@ -87,7 +87,7 @@ public class DigitsManager extends ReactContextBaseJavaModule implements Lifecyc
         WritableMap sessionData = new WritableNativeMap();
         sessionData.putString("userId", new Long(session.getId()).toString());
         sessionData.putString("phoneNumber", new Long(session.getPhoneNumber()).toString());
-        callback.invoke(sessionData);
+        callback.invoke(null, sessionData);
     }
 
     private TwitterAuthConfig getTwitterAuthConfig() {


### PR DESCRIPTION
The sessionDetails call for iOS sends back (null, sessionDetails) so this brings the Android version up to date with that API by always passing in `null` for the error argument.

https://github.com/JeanLebrument/react-native-fabric-digits/blob/master/ios/RCTDigitsManager.m#L120
