### PR TITLE
Phone numbers prefixed with + crashes

### DIFF
--- a/android/src/main/java/com/proxima/RCTDigits/DigitsManager.java
+++ b/android/src/main/java/com/proxima/RCTDigits/DigitsManager.java
@@ -81,7 +81,7 @@ public class DigitsManager extends ReactContextBaseJavaModule implements Lifecyc
         if (session != null) {
             WritableMap sessionData = new WritableNativeMap();
             sessionData.putString("userId", new Long(session.getId()).toString());
-            sessionData.putString("phoneNumber", new Long(session.getPhoneNumber()).toString());
+            sessionData.putString("phoneNumber", session.getPhoneNumber().replaceAll("[^0-9]", ""));
             callback.invoke(null, sessionData);
         } else {
             callback.invoke(null, null);


### PR DESCRIPTION
solves issue #18 

In some cases the phone number is returned with a + prefix which made conversion to Long crash.
Fixed by removing all non-numeric characters.