### PR TITLE
return all properties, fix phone number on ios should same as android

### DIFF
--- a/android/src/main/java/com/proxima/RCTDigits/DigitsManager.java
+++ b/android/src/main/java/com/proxima/RCTDigits/DigitsManager.java
@@ -42,6 +42,10 @@ public class DigitsManager extends ReactContextBaseJavaModule implements Lifecyc
 
     public DigitsManager(ReactApplicationContext reactContext) {
         super(reactContext);
+
+        // Check for Twitter config
+        TwitterAuthConfig authConfig = getTwitterAuthConfig();
+        Fabric.with(getReactApplicationContext(), new TwitterCore(authConfig), new Digits.Builder().build());
     }
 
     @Override
@@ -59,12 +63,8 @@ public class DigitsManager extends ReactContextBaseJavaModule implements Lifecyc
         getReactApplicationContext().addLifecycleEventListener(this);
         this.promise = promise;
 
-        String phoneNumber = options != null && options.hasKey("phoneNumber") ? 
+        String phoneNumber = options != null && options.hasKey("phoneNumber") ?
             options.getString("phoneNumber") : "";
-
-        // Check for Twitter config
-        TwitterAuthConfig authConfig = getTwitterAuthConfig();
-        Fabric.with(getReactApplicationContext(), new TwitterCore(authConfig), new Digits.Builder().build());
 
         AuthConfig.Builder digitsAuthConfigBuilder = new AuthConfig.Builder()
                 .withAuthCallBack(this)
@@ -87,8 +87,12 @@ public class DigitsManager extends ReactContextBaseJavaModule implements Lifecyc
         DigitsSession session = Digits.getActiveSession();
         if (session != null) {
             WritableMap sessionData = new WritableNativeMap();
+            sessionData.putString("authToken", session.getAuthToken().token);
+            sessionData.putString("authTokenSecret", session.getAuthToken().secret);
             sessionData.putString("userId", new Long(session.getId()).toString());
             sessionData.putString("phoneNumber", session.getPhoneNumber().replaceAll("[^0-9]", ""));
+            sessionData.putString("emailAddress", session.getEmail().address);
+            sessionData.putBoolean("emailAddressIsVerified", session.getEmail().verified);
             callback.invoke(null, sessionData);
         } else {
             callback.invoke(null, null);

--- a/ios/RCTDigitsManager.m
+++ b/ios/RCTDigitsManager.m
@@ -114,9 +114,20 @@ RCT_EXPORT_METHOD(logout) {
 RCT_EXPORT_METHOD(sessionDetails:(RCTResponseSenderBlock)callback) {
     DGTSession* session =[[Digits sharedInstance] session];
     if (session) {
+        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"[^0-9]"
+                                                                               options:NSRegularExpressionCaseInsensitive
+                                                                                 error:nil];
+        NSString *phoneNumber = [regex stringByReplacingMatchesInString:session.phoneNumber
+                                                                options:0
+                                                                  range:NSMakeRange(0, session.phoneNumber.length)
+                                                           withTemplate:@""];
         NSDictionary *events = @{
+                                 @"authToken": session.authToken,
+                                 @"authTokenSecret": session.authTokenSecret,
                                  @"userID": session.userID,
-                                 @"phoneNumber": session.phoneNumber,
+                                 @"phoneNumber": phoneNumber,
+                                 @"emailAddress": (session.emailAddress ? session.emailAddress : @""),
+                                 @"emailAddressIsVerified": @(session.emailAddressIsVerified)
                                  };
         callback(@[[NSNull null], events]);
     } else {


### PR DESCRIPTION
- Moving `Fabric.with` to constructor, so we can call `sessionDetails` for initial session checking or manually logout using `NativeModules` without `DigitsLogoutButton` component.
- On iOS, phone number should same string as Android.
- And last, return all Digits Session properties.