### PR TITLE
rename field userID to userId to match android casing

### DIFF
--- a/ios/RCTDigitsManager.m
+++ b/ios/RCTDigitsManager.m
@@ -124,7 +124,7 @@ RCT_EXPORT_METHOD(sessionDetails:(RCTResponseSenderBlock)callback) {
         NSDictionary *events = @{
                                  @"authToken": session.authToken,
                                  @"authTokenSecret": session.authTokenSecret,
-                                 @"userID": session.userID,
+                                 @"userId": session.userID,
                                  @"phoneNumber": phoneNumber,
                                  @"emailAddress": (session.emailAddress ? session.emailAddress : @""),
                                  @"emailAddressIsVerified": @(session.emailAddressIsVerified)


### PR DESCRIPTION
Hey,

the two sessionDetail objects are not identical at the moment
(see: https://github.com/JeanLebrument/react-native-fabric-digits/blob/master/ios/RCTDigitsManager.m#L127)
(and: https://github.com/JeanLebrument/react-native-fabric-digits/blob/master/android/src/main/java/com/proxima/RCTDigits/DigitsManager.java#L92)

I changed it to match the android version as I prefered the `userId` over `userID` casing. Please tell me if you'd prefer to use the iOS casing.